### PR TITLE
show codelens for "specify" and "scenario"

### DIFF
--- a/src/rspec/SpecParser.ts
+++ b/src/rspec/SpecParser.ts
@@ -6,7 +6,7 @@ interface SpecRegion {
 };
 
 export class SpecParser {
-  private matcher = /(?:(?:^\s*(?:RSpec\.)?(?:it|context|example|specify|scenario)\(?\s*(?:(['"])(?<title>.*)\1)?\)?\s*(?:,\s*[\w:'"]+\s*(?:=>)?\s*['":\w]+)?\s*(?:do|{))|(?:^\s*(?:it_behaves_like|include_examples)\s*(['"])(?:.*)\3\s*(?:do|{)?)|(?:^\s*(?:RSpec\.)?describe\(?\s*(?:(?<describedClass>[\w:\.]+)|(?:(['"])(?<describedString>.*)\5))\)?\s*(?:,\s*:?['"\w]+\s*(?:=>|:)\s*['"\w:]+\s*)*\s*(?:do|{))|(?:^\s*(?:it|example)\s*{(?<singleLine>.*)}))\s*(?:#.*)?$/;
+  private matcher = /(?:(?:^\s*(?:RSpec\.)?(?:it|context|example|specify|scenario)\(?\s*(?:(['"])(?<title>.*)\1)?\)?\s*(?:,\s*[\w:'"]+\s*(?:=>)?\s*['":\w]+)?\s*(?:do|{))|(?:^\s*(?:it_behaves_like|include_examples)\s*(['"])(?:.*)\3\s*(?:do|{)?)|(?:^\s*(?:RSpec\.)?(?:describe|feature)\(?\s*(?:(?<describedClass>[\w:\.]+)|(?:(['"])(?<describedString>.*)\5))\)?\s*(?:,\s*:?['"\w]+\s*(?:=>|:)\s*['"\w:]+\s*)*\s*(?:do|{))|(?:^\s*(?:it|example|specify|scenario)\s*{(?<singleLine>.*)}))\s*(?:#.*)?$/;
   private document: TextDocument;
 
   constructor(document: TextDocument) {

--- a/src/rspec/SpecParser.ts
+++ b/src/rspec/SpecParser.ts
@@ -6,7 +6,7 @@ interface SpecRegion {
 };
 
 export class SpecParser {
-  private matcher = /(?:(?:^\s*(?:RSpec\.)?(?:it|context|example)\(?\s*(?:(['"])(?<title>.*)\1)?\)?\s*(?:,\s*[\w:'"]+\s*(?:=>)?\s*['":\w]+)?\s*(?:do|{))|(?:^\s*(?:it_behaves_like|include_examples)\s*(['"])(?:.*)\3\s*(?:do|{)?)|(?:^\s*(?:RSpec\.)?describe\(?\s*(?:(?<describedClass>[\w:\.]+)|(?:(['"])(?<describedString>.*)\5))\)?\s*(?:,\s*:?['"\w]+\s*(?:=>|:)\s*['"\w:]+\s*)*\s*(?:do|{))|(?:^\s*(?:it|example)\s*{(?<singleLine>.*)}))\s*(?:#.*)?$/;
+  private matcher = /(?:(?:^\s*(?:RSpec\.)?(?:it|context|example|specify|scenario)\(?\s*(?:(['"])(?<title>.*)\1)?\)?\s*(?:,\s*[\w:'"]+\s*(?:=>)?\s*['":\w]+)?\s*(?:do|{))|(?:^\s*(?:it_behaves_like|include_examples)\s*(['"])(?:.*)\3\s*(?:do|{)?)|(?:^\s*(?:RSpec\.)?describe\(?\s*(?:(?<describedClass>[\w:\.]+)|(?:(['"])(?<describedString>.*)\5))\)?\s*(?:,\s*:?['"\w]+\s*(?:=>|:)\s*['"\w:]+\s*)*\s*(?:do|{))|(?:^\s*(?:it|example)\s*{(?<singleLine>.*)}))\s*(?:#.*)?$/;
   private document: TextDocument;
 
   constructor(document: TextDocument) {


### PR DESCRIPTION
I just discovered this extension today and LOVE it!

One thing I noticed is that the Run button doesn't show over tests marked as Capybara "scenario" (alias for "example"). When I change it to example it shows up. 

I went ahead and added "scenario" and "specify" (another "it" alias) to the regex in SpecParser.

I've never managed a VSCode extension before, but I ran the `yarn package` on my local forked copy and copied the "dist" folder to my existing install. It worked there.

![image](https://user-images.githubusercontent.com/1305/228936735-a73ee4e5-3c16-4ad8-8d0f-d73a607a8546.png)

Hope this is useful and something you can add to the extension. I did a couple of posts on Reddit today about the extension. I thin more people need to know about this one! It was the extension that finally made me not yearn to switch back to RubyMine for the testing UI.