### PR TITLE
add a "Run all examples" button as a **proof-of-concept**

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
 			{
 				"command": "ruby-spec-runner.clearResults",
 				"title": "Ruby Spec Runner: Clear test results for this file"
+			},
+			{
+				"command": "ruby-spec-runner.runAllExamples",
+				"title": "Ruby Spec Runner: Run all examples"
 			}
 		],
 		"keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import { SpecRunnerConfig } from './SpecRunnerConfig';
 import SpecResultInterpreter from './rspec/SpecResultInterpreter';
 import SpecResultPresenter from './SpecResultPresenter';
 import { MinitestRunner, MinitestRunnerCodeLensProvider, MinitestRunnerButton, MinitestResultInterpreter } from './minitest';
-import { SpecRunner, SpecRunnerCodeLensProvider, FailedSpecRunnerButton, SpecRunnerButton } from './rspec';
+import { SpecRunner, SpecRunnerCodeLensProvider, FailedSpecRunnerButton, SpecRunnerButton, AllSpecsRunnerButton } from './rspec';
 import { RunRspecOrMinitestArg } from './types';
 
 // This method is called when the extension is activated
@@ -64,6 +64,12 @@ export function activate(context: vscode.ExtensionContext) {
     'ruby-spec-runner.runFailedExamples',
     async () => specRunner.runFailedExample()
   );
+
+  const runAllSpecs = vscode.commands.registerCommand(
+    'ruby-spec-runner.runAllExamples',
+    async () => specRunner.runAllExamples()
+  );
+
   const clearResults = vscode.commands.registerCommand(
     'ruby-spec-runner.clearResults',
     async () => resultPresenter.clearTestResults()
@@ -84,18 +90,22 @@ export function activate(context: vscode.ExtensionContext) {
   const failedSpecRunnerButton = new FailedSpecRunnerButton(vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1), config);
   const specRunnerButton = new SpecRunnerButton(vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 2), config);
   const minitestRunnerButton = new MinitestRunnerButton(vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 2), config);
+  const allSpecsRunnerButton = new AllSpecsRunnerButton(vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 3), config);
 
   context.subscriptions.push(runRspecOrMinitestFile);
   context.subscriptions.push(runRspecOrMinitestLine);
   context.subscriptions.push(clearResults);
   context.subscriptions.push(runFailedExample);
+  context.subscriptions.push(runAllSpecs);
   context.subscriptions.push(specCodeLensProviderDisposable);
   context.subscriptions.push(minitestCodeLensProviderDisposable);
   context.subscriptions.push(specRunnerButton.button);
   context.subscriptions.push(failedSpecRunnerButton.button);
+  context.subscriptions.push(allSpecsRunnerButton.button);
   context.subscriptions.push(minitestRunnerButton.button);
   context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor((editor) => {
     failedSpecRunnerButton.update(editor);
+    allSpecsRunnerButton.update(editor);
     specRunnerButton.update(editor);
     minitestRunnerButton.update(editor);
     resultPresenter.update();
@@ -106,6 +116,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 
   failedSpecRunnerButton.update();
+  allSpecsRunnerButton.update();
   specRunnerButton.update();
   minitestRunnerButton.update();
 }

--- a/src/rspec/AllSpecsRunnerButton.ts
+++ b/src/rspec/AllSpecsRunnerButton.ts
@@ -1,0 +1,31 @@
+import * as vscode from 'vscode';
+import SpecRunnerConfig from '../SpecRunnerConfig';
+
+export class AllSpecsRunnerButton {
+  button: vscode.StatusBarItem;
+  private config: SpecRunnerConfig;
+
+  constructor(button: vscode.StatusBarItem, config: SpecRunnerConfig) {
+    this.button = button;
+    this.config = config;
+  }
+
+  update(editor = vscode.window.activeTextEditor) {
+    // if (!editor || !this.config.rspecRunAllFailedButton) {
+    //   this.button.hide();
+    //   return;
+    // }
+
+    // const doc = editor.document;
+    // if (doc.languageId !== 'ruby' || !doc.fileName.match(/_spec\.rb$/)) {
+    //   this.button.hide();
+    //   return;
+    // }
+
+    this.button.text = '$(testing-run-icon) Run all examples';
+    this.button.command = 'ruby-spec-runner.runAllExamples';
+    this.button.show();
+  }
+}
+
+export default AllSpecsRunnerButton;

--- a/src/rspec/SpecRunner.ts
+++ b/src/rspec/SpecRunner.ts
@@ -36,6 +36,10 @@ export class SpecRunner {
     this.runCurrentSpec(true);
   }
 
+  async runAllExamples() {
+    console.log("running all specs");
+  }
+
   async runSpecForFile(fileName: string, failedOnly:boolean, line?: number, testName?: string) {
     try {
       const command = this.buildRspecCommand(fileName, failedOnly, line, testName);

--- a/src/rspec/index.ts
+++ b/src/rspec/index.ts
@@ -1,4 +1,5 @@
 export * from './FailedSpecRunnerButton';
+export * from './AllSpecsRunnerButton';
 export * from './SpecRunner';
 export * from './SpecRunnerButton';
 export * from './SpecRunnerCodeLensProvider';


### PR DESCRIPTION
It would be nice to have a "Run all examples/specs" button that's always visible. I had a quick look at the codebase and managed to put together this proof-of-concept for it.

As far as I can tell the extension is only activated when a spec file is opened, but for this to work we'd need to detect whether we're in a project/folder containing specs. Until I open a spec the button doesn't appear.

Is this something you're interested in incorporating? I'm willing to work on the feature if so.