### PR TITLE
Fix Issue 11: Fish shell incompatibility with changeDirectoryToWorkspaceRoot setting

### DIFF
--- a/src/rspec/SpecRunner.ts
+++ b/src/rspec/SpecRunner.ts
@@ -121,6 +121,10 @@ export class SpecRunner {
     const rspecCommand = [stringifyEnvs(this.config.rspecEnv), this.config.rspecCommand, failedOnlyModifier, format, jsonOutput, quote(file)].filter(Boolean).join(' ');
 
     const fullCommand = cmdJoin(cdCommand, rspecCommand, returnCommand || '');
+
+    // IMPORTANT: Fish shell compatibility depends on the cdCommands function in util.ts
+    // For Fish shell, returnCommand should never be false to avoid parentheses syntax
+    // which Fish interprets as command substitution rather than command grouping
     return returnCommand === false ? `(${fullCommand})` : fullCommand;
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,15 +17,33 @@ export function teeCommand(outputFile: string, append = false, bashInWindowsOver
 }
 
 /**
+ * Detect if the current shell is Fish
+ */
+export function isFishShell(): boolean {
+  const shell = process.env.SHELL;
+  return shell ? shell.endsWith('/fish') : false;
+}
+
+/**
  * Returns two commands, the cdCommand and the returnCommand.
  *
  * If the returnCommand is false, then that means we should use a subshell to handle
  * returning to the current directory.
+ * 
+ * For Fish shell, we use pushd/popd instead of parentheses grouping
  */
 export function cdCommands(path: string, bashInWindowsOverride = false): [string, string | false] {
   if (isWindows() && !bashInWindowsOverride) {
     return [`pushd ${quote(path)} >nul`, 'popd >nul'];
   }
+
+  // Check if we're using Fish shell
+  if (isFishShell()) {
+    // Fish shell doesn't support the parentheses grouping syntax
+    // Use pushd/popd instead which works in Fish
+    return [`pushd ${quote(path)}`, 'popd'];
+  }
+  
   return [`cd ${quote(path)}`, false];
 }
 


### PR DESCRIPTION
Fixes #11 

I tested it with default Fish shell and default bash shell with the `changeDirectoryToWorkspaceRoot` set to true and it works.