### PR TITLE
Focus debug console when debugging

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,9 @@ const buildFileRunnerHandler = (minitestRunner: MinitestRunner, specRunner: Spec
     if (debugging) { return; } // Minitest debugging does not seem to work :(
     minitestRunner.runTest({ ...args, debugging });
   } else {
+    if (debugging) {
+      vscode.commands.executeCommand('workbench.action.debug.console.focus');
+    }
     specRunner.runSpec({ ...args, debugging });
   }
 };
@@ -56,6 +59,9 @@ const buildLineRunnerHandler = (minitestRunner: MinitestRunner, specRunner: Spec
       forLines: nearestTestOrContext.forTestLines?.map(line => line + 1)
     });
   } else {
+    if (debugging) {
+      vscode.commands.executeCommand('workbench.action.debug.console.focus');
+    }
     specRunner.runSpec(args);
   }
 };


### PR DESCRIPTION
Hello, really enjoying using this extension.

This PR causes VS code to automatically focus the debug console when debugging a test via the codelens action or the statusbar item

Currently not a configurable option, but could add it as a boolean named something like "Auto-focus debug console when debugging"