### PR TITLE
Add separate formatter config for single line runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,17 @@
 					"markdownDescription": "Rspec: Output format for rspec.\n\n- **Documentation:** group and example names\n- **Progress:** dots for each example",
 					"scope": "window"
 				},
+				"ruby-spec-runner.rspecSingleLineFormat": {
+					"type": "string",
+					"enum": [
+						"Documentation",
+						"Progress",
+						"Use Default Format"
+					],
+					"default": "Use Default Format",
+					"markdownDescription": "Rspec: Output format for single line tests (when running individual examples).\n\n- **Documentation:** group and example names\n- **Progress:** dots for each example\n- **Use Default Format:** use the same format as `rspecFormat`",
+					"scope": "window"
+				},
 				"ruby-spec-runner.saveBeforeRunning": {
 					"type": "boolean",
 					"default": true,

--- a/src/SpecRunnerConfig.ts
+++ b/src/SpecRunnerConfig.ts
@@ -52,6 +52,20 @@ export class SpecRunnerConfig {
     };
   }
 
+  get rspecSingleLineFormat(): string {
+    const format = vscode.workspace.getConfiguration().get('ruby-spec-runner.rspecSingleLineFormat') as string | undefined;
+
+    switch (format) {
+      case 'Documentation':
+        return 'd';
+      case 'Progress':
+        return 'p';
+      case 'Use Default Format':
+      default:
+        return this.rspecFormat;
+    };
+  }
+
   get overviewHighlightPosition() {
     const format = vscode.workspace.getConfiguration().get('ruby-spec-runner.overviewHighlightPosition') as string | undefined;
 

--- a/src/rspec/SpecRunner.ts
+++ b/src/rspec/SpecRunner.ts
@@ -81,7 +81,7 @@ export class SpecRunner {
           script: quote(line ? [fileName, ':', line].join('') : fileName),
           env: {...this.config.rspecEnv, ...this.config.rspecDebugEnv},
           args: [
-            `-f ${this.config.rspecFormat}`,
+            `-f ${this.getRspecFormat(line)}`,
             this.config.rspecDecorateEditorWithResults ? `-f j --out ${quote(this.outputFilePath)}` : undefined
           ].filter(Boolean),
           askParameters: false,
@@ -96,7 +96,7 @@ export class SpecRunner {
           request: 'launch',
           program: [
             this.config.rspecCommand,
-            `-f ${this.config.rspecFormat}`,
+            `-f ${this.getRspecFormat(line)}`,
             this.config.rspecDecorateEditorWithResults ? `-f j --out ${quote(this.outputFilePath)}` : undefined,
             quote(line ? [fileName, ':', line].join('') : fileName)
           ].filter(Boolean).join(' '),
@@ -114,7 +114,7 @@ export class SpecRunner {
   private buildRspecCommand(fileName: string, failedOnly: boolean, line?: number, testName?: string) {
     const file = line ? [fileName, ':', line].join('') : fileName;
     const failedOnlyModifier = failedOnly ? '--only-failures' : '';
-    const format = `-f ${this.config.rspecFormat}`;
+    const format = `-f ${this.getRspecFormat(line)}`;
     const jsonOutput = this.config.rspecDecorateEditorWithResults ? `-f j --out ${quote(this.outputFilePath)}` : '';
 
     const [cdCommand, returnCommand] = this.buildChangeDirectoryToWorkspaceRootCommand();
@@ -156,6 +156,10 @@ export class SpecRunner {
     }
 
     return this._term;
+  }
+
+  private getRspecFormat(line?: number): string {
+    return line ? this.config.rspecSingleLineFormat : this.config.rspecFormat;
   }
 };
 


### PR DESCRIPTION
This allows single line test runs to have the documentation formatter and full spec runs to use progress.

Configurable, with the default option set to fall back to the existing formatter config